### PR TITLE
Asynchronous Implementation of the API

### DIFF
--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -320,7 +320,7 @@ public class StreamingParser: HTTPResponseWriter {
                         //  just passing in a pointer to the internal ivar. But that ivar can't be modified in
                         //  more than one place, so we have to put a semaphore around it to prevent that.
                         _shouldStopProcessingBodyLock.wait()
-                        handler(.chunk(data: chunk, finishedProcessing: {self._shouldStopProcessingBodyLock.signal()}), &_shouldStopProcessingBody)
+                        handler(.chunk(data: chunk, finishedProcessing: { self._shouldStopProcessingBodyLock.signal() }), &_shouldStopProcessingBody)
                     case .discardBody:
                         break
                 }

--- a/Sources/HTTP/HTTPVersion.swift
+++ b/Sources/HTTP/HTTPVersion.swift
@@ -25,7 +25,9 @@ extension HTTPVersion: Hashable {
     public var hashValue: Int {
         return (major << 8) | minor
     }
+}
 
+extension HTTPVersion {
     /// :nodoc:
     public static func == (lhs: HTTPVersion, rhs: HTTPVersion) -> Bool {
         return lhs.major == rhs.major && lhs.minor == rhs.minor
@@ -46,12 +48,11 @@ extension HTTPVersion: Comparable {
             return lhs.minor < rhs.minor
         }
     }
-
 }
 
 extension HTTPVersion: CustomStringConvertible {
     /// :nodoc:
     public var description: String {
-        return "HTTP/" + major.description + "." + minor.description
+        return "HTTP/\(major).\(minor)"
     }
 }

--- a/Sources/HTTP/PoCSocket/PoCSocket.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocket.swift
@@ -19,9 +19,9 @@ public enum PoCSocketError: Error {
 }
 
 /// Simple Wrapper around the `socket(2)` functions we need for Proof of Concept testing
-///  Intentionally a thin layer over `recv(2)`/`send(2)` so uses the same argument types.
-///  Note that no method names here are the same as any system call names.
-///   This is because we expect the caller might need functionality we haven't implemented here.
+/// Intentionally a thin layer over `recv(2)`/`send(2)` so uses the same argument types.
+/// Note that no method names here are the same as any system call names.
+/// This is because we expect the caller might need functionality we haven't implemented here.
 internal class PoCSocket {
 
     /// hold the file descriptor for the socket supplied by the OS. `-1` is invalid socket
@@ -100,14 +100,14 @@ internal class PoCSocket {
             throw PoCSocketError.InvalidWriteLengthError
         }
 
-        //Make sure we weren't handed a nil buffer
+        // Make sure we weren't handed a nil buffer
         let writeBufferPointer: UnsafeRawPointer! = buffer
         if writeBufferPointer == nil {
             throw PoCSocketError.InvalidBufferError
         }
 
         let sent = send(self.socketfd, buffer, Int(bufSize), Int32(0))
-        //Leave this as a local variable to facilitate Setting a Watchpoint in lldb
+        // Leave this as a local variable to facilitate Setting a Watchpoint in lldb
         return sent
     }
 
@@ -118,9 +118,7 @@ internal class PoCSocket {
             //Nothing to do. Maybe it was closed already
             return
         }
-        //print("Shutting down socket \(self.socketfd)")
         if self.isListening || self.isConnected {
-            //print("Shutting down socket")
             _ = shutdown(self.socketfd, Int32(SHUT_RDWR))
             self.isListening = false
         }
@@ -217,13 +215,9 @@ internal class PoCSocket {
             bind(self.socketfd, UnsafePointer<sockaddr>(OpaquePointer($0)), socklen_t(MemoryLayout<sockaddr_in>.size))
         }
 
-        //print("bindResult is \(bindResult)")
-
         _ = listen(self.socketfd, maxBacklogSize)
 
         isListening = true
-
-        //print("listenResult is \(listenResult)")
 
         var addr_in = sockaddr_in()
 
@@ -238,8 +232,6 @@ internal class PoCSocket {
                 return Int32(Int(OSHostByteOrder()) != OSLittleEndian ? addr_in.sin_port.littleEndian : addr_in.sin_port.bigEndian)
             #endif
         }
-
-        //print("listeningPort is \(listeningPort)")
     }
 
     /// Check to see if socket is being used

--- a/Sources/HTTP/PoCSocket/PoCSocketConnectionListener.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocketConnectionListener.swift
@@ -12,13 +12,13 @@ import Dispatch
 ///:nodoc:
 public class PoCSocketConnectionListener: ParserConnecting {
 
-    ///socket(2) wrapper object
+    /// socket(2) wrapper object
     var socket: PoCSocket?
 
-    ///ivar for the thing that manages the CHTTP Parser
+    /// ivar for the thing that manages the CHTTP Parser
     var parser: StreamingParser?
 
-    ///Save the socket file descriptor so we can loook at it for debugging purposes
+    /// Save the socket file descriptor so we can loook at it for debugging purposes
     var socketFD: Int32
     var shouldShutdown: Bool = false
 
@@ -26,10 +26,10 @@ public class PoCSocketConnectionListener: ParserConnecting {
     let socketReaderQueue: DispatchQueue
     let socketWriterQueue: DispatchQueue
 
-    ///Event handler for reading from the socket
+    /// Event handler for reading from the socket
     private var readerSource: DispatchSourceRead?
 
-    ///Flag to track whether we're in the middle of a response or not (with lock)
+    /// Flag to track whether we're in the middle of a response or not (with lock)
     private let _responseCompletedLock = DispatchSemaphore(value: 1)
     private var _responseCompleted: Bool = false
     var responseCompleted: Bool {
@@ -49,7 +49,7 @@ public class PoCSocketConnectionListener: ParserConnecting {
         }
     }
 
-    ///Flag to track whether we've received a socket error or not (with lock)
+    /// Flag to track whether we've received a socket error or not (with lock)
     private let _errorOccurredLock = DispatchSemaphore(value: 1)
     private var _errorOccurred: Bool = false
     var errorOccurred: Bool {
@@ -69,8 +69,8 @@ public class PoCSocketConnectionListener: ParserConnecting {
         }
     }
 
-    ///Largest number of bytes we're willing to allocate for a Read
-    // it's an anti-heartbleed-type paranoia check
+    /// Largest number of bytes we're willing to allocate for a Read
+    /// it's an anti-heartbleed-type paranoia check
     private var maxReadLength: Int = 1048576
 
     /// initializer
@@ -92,10 +92,7 @@ public class PoCSocketConnectionListener: ParserConnecting {
 
     /// Check if socket is still open. Used to decide whether it should be closed/pruned after timeout
     public var isOpen: Bool {
-        guard let socket = self.socket else {
-            return false
-        }
-        return socket.isOpen()
+        return self.socket?.isOpen() ?? false
     }
 
     /// Close the socket and free up memory unless we're in the middle of a request
@@ -109,7 +106,7 @@ public class PoCSocketConnectionListener: ParserConnecting {
             self.socket?.shutdownAndClose()
         }
 
-        //In a perfect world, we wouldn't have to clean this all up explicitly,
+        // In a perfect world, we wouldn't have to clean this all up explicitly,
         // but KDE/heaptrack informs us we're in far from a perfect world
 
         if !(self.readerSource?.isCancelled ?? true) {
@@ -152,7 +149,7 @@ public class PoCSocketConnectionListener: ParserConnecting {
     /// Check if the socket is idle, and if so, call close()
     func closeIfIdleSocket() {
         if !self.responseCompleted {
-            //We're in the middle of a connection - we're not idle
+            // We're in the middle of a connection - we're not idle
             return
         }
         let now = Date().timeIntervalSinceReferenceDate
@@ -198,9 +195,9 @@ public class PoCSocketConnectionListener: ParserConnecting {
     /// Starts reading from the socket and feeding that data to the parser
     public func process() {
         let tempReaderSource: DispatchSourceRead
-        //Make sure we have a socket here.  Don't use guard so that
-        //  we don't encourage strongSocket to be used in the
-        //  event handler, which could cause a leak
+        // Make sure we have a socket here.  Don't use guard so that
+        // we don't encourage strongSocket to be used in the
+        // event handler, which could cause a leak
         if let strongSocket = socket {
             do {
                 try strongSocket.setBlocking(mode: true)
@@ -238,7 +235,7 @@ public class PoCSocketConnectionListener: ParserConnecting {
                     if (maxLength > strongSelf.maxReadLength) || (maxLength <= 0) {
                             maxLength = strongSelf.maxReadLength
                     }
-                    var readBuffer: UnsafeMutablePointer<Int8> = UnsafeMutablePointer<Int8>.allocate(capacity: maxLength)
+                    var readBuffer = UnsafeMutablePointer<Int8>.allocate(capacity: maxLength)
                     length = try strongSelf.socket?.socketRead(into: &readBuffer, maxLength: maxLength) ?? -1
                     defer {
                         readBuffer.deallocate(capacity: maxLength)

--- a/Sources/HTTP/PoCSocket/PoCSocketConnectionListener.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocketConnectionListener.swift
@@ -240,6 +240,9 @@ public class PoCSocketConnectionListener: ParserConnecting {
                     }
                     var readBuffer: UnsafeMutablePointer<Int8> = UnsafeMutablePointer<Int8>.allocate(capacity: maxLength)
                     length = try strongSelf.socket?.socketRead(into: &readBuffer, maxLength: maxLength) ?? -1
+                    defer {
+                        readBuffer.deallocate(capacity: maxLength)
+                    }
                     if length > 0 {
                         self?.responseCompleted = false
 
@@ -250,7 +253,6 @@ public class PoCSocketConnectionListener: ParserConnecting {
                             print("Error: wrong number of bytes consumed by parser (\(numberParsed) instead of \(data.count)")
                         }
                     }
-                    readBuffer.deallocate(capacity: maxLength)
                 } else {
                     print("bad socket FD while reading")
                     length = -1

--- a/Tests/HTTPTests/Helpers/AbortAndSendHelloHandler.swift
+++ b/Tests/HTTPTests/Helpers/AbortAndSendHelloHandler.swift
@@ -11,10 +11,10 @@ import HTTP
 
 /// Simple `HTTPRequestHandler` that prints "Hello, World" as per K&R
 class AbortAndSendHelloHandler: HTTPRequestHandling {
-    
-    var chunkCalledCount=0
-    var chunkLength=0
-    
+
+    var chunkCalledCount = 0
+    var chunkLength = 0
+
     func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         response.writeHeader(status: .ok, headers: [.transferEncoding: "chunked", "X-foo": "bar"])

--- a/Tests/HTTPTests/Helpers/TestResponseResolver.swift
+++ b/Tests/HTTPTests/Helpers/TestResponseResolver.swift
@@ -17,7 +17,7 @@ class TestResponseResolver: HTTPResponseWriter {
 
     var response: (status: HTTPResponseStatus, headers: HTTPHeaders)?
     var responseBody: HTTPResponseBody?
-    
+
     ///Flag to track whether our handler has told us not to call it anymore
     private let _shouldStopProcessingBodyLock = DispatchSemaphore(value: 1)
     private var _shouldStopProcessingBody: Bool = false
@@ -57,7 +57,7 @@ class TestResponseResolver: HTTPResponseWriter {
         switch chunkHandler {
             case .processBody(let handler):
                 _shouldStopProcessingBodyLock.wait()
-                handler(.chunk(data: self.requestBody, finishedProcessing: {self._shouldStopProcessingBodyLock.signal()}), &_shouldStopProcessingBody)
+                handler(.chunk(data: self.requestBody, finishedProcessing: { self._shouldStopProcessingBodyLock.signal() }), &_shouldStopProcessingBody)
                 var dummy = false
                 handler(.end, &dummy)
             case .discardBody:

--- a/Tests/HTTPTests/ServerTests.swift
+++ b/Tests/HTTPTests/ServerTests.swift
@@ -276,7 +276,7 @@ class ServerTests: XCTestCase {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
     }
-    
+
     func testMultipleRequestWithoutKeepAliveEchoEndToEnd() {
         let receivedExpectation1 = self.expectation(description: "Received web response 1: \(#function)")
         let receivedExpectation2 = self.expectation(description: "Received web response 2: \(#function)")
@@ -284,7 +284,7 @@ class ServerTests: XCTestCase {
         let testString1="This is a test"
         let testString2="This is a test, too"
         let testString3="This is also a test"
-        
+
         let server = HTTPServer()
         do {
             try server.start(port: 0, handler: EchoHandler().handle)
@@ -356,7 +356,7 @@ class ServerTests: XCTestCase {
                 receivedExpectation1.fulfill()
             }
             dataTask1.resume()
-            
+
             self.waitForExpectations(timeout: 10) { (error) in
                 if let error = error {
                     XCTFail("\(error)")
@@ -367,7 +367,6 @@ class ServerTests: XCTestCase {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
     }
-
 
     func testRequestLargeEchoEndToEnd() {
         let receivedExpectation = self.expectation(description: "Received web response \(#function)")
@@ -425,29 +424,29 @@ class ServerTests: XCTestCase {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
     }
-    
+
     func testRequestLargePostHelloWorld() {
         let receivedExpectation = self.expectation(description: "Received web response \(#function)")
-        
+
         //Use a small chunk size to make sure that we stop after one HTTPBodyHandler call
         let chunkSize = 1024
-        
+
         // Get a file we know exists
         let executableURL = URL(fileURLWithPath: CommandLine.arguments[0])
         let testExecutableData: Data
-        
+
         do {
             testExecutableData = try Data(contentsOf: executableURL)
         } catch {
             XCTFail("Could not create Data from contents of \(executableURL)")
             return
         }
-        
+
         //Make sure there's data there
         XCTAssertNotNil(testExecutableData)
-        
+
         let executableLength = testExecutableData.count
-                
+
         let server = PoCSocketSimpleServer()
         do {
             let testHandler = AbortAndSendHelloHandler()
@@ -481,7 +480,6 @@ class ServerTests: XCTestCase {
         }
     }
 
-
     func testExplicitCloseConnections() {
         let expectation = self.expectation(description: "0 Open Connection")
         let server = PoCSocketSimpleServer()
@@ -489,19 +487,19 @@ class ServerTests: XCTestCase {
 
         do {
             try server.start(port: 0, keepAliveTimeout: keepAliveTimeout, handler: OkHandler().handle)
-            
+
             let session = URLSession(configuration: .default)
             let url1 = URL(string: "http://localhost:\(server.port)")!
             var request = URLRequest(url: url1)
             request.httpMethod = "POST"
             request.setValue("close", forHTTPHeaderField: "Connection")
-            
-            let dataTask1 = session.dataTask(with: request) { (responseBody, rawResponse, error) in
+
+            let dataTask1 = session.dataTask(with: request) { (_, _, error) in
                 XCTAssertNil(error, "\(error!.localizedDescription)")
                 #if os(Linux)
                     XCTAssertEqual(server.connectionCount, 0)
                     expectation.fulfill()
-                
+
                     // Darwin's URLSession replaces the `Connection: close` header with `Connection: keep-alive`, so allow it to expire
                 #else
                     DispatchQueue.main.asyncAfter(deadline: .now() + keepAliveTimeout) {
@@ -511,7 +509,7 @@ class ServerTests: XCTestCase {
                 #endif
             }
             dataTask1.resume()
-            
+
             self.waitForExpectations(timeout: 30) { (error) in
                 if let error = error {
                     XCTFail("\(error)")


### PR DESCRIPTION
This PR contains a GCD DispatchIO based implementation of the API and presumably should scale significantly better than the synchronous one. Throughput should be a little worse for obvious reasons.

I also setup a small test server demonstrating the API: [http-testserver](https://github.com/ZeeZide/http-testserver). Of special interest is the `slow` handler, which does the typical `sleep()` async demo.

Unlike Noze.io or Node.js it does not use a single network processing queue, but rather a set of base queues as suggested by Johannes. To support that, the handler API has been enhanced with the `queue` argument. All API calls of a handler need to be dispatched back to that (but the handler itself runs on the same queue, so the trivial cases require no extra work).

This implementation is supposed to support back pressure and pipelining.

Caveats:
- tests don't work
- little testing has been done, probably has tons of bugs ;-)
